### PR TITLE
Remove one more reference to 'pseudoloc.cov'

### DIFF
--- a/index.js
+++ b/index.js
@@ -5,7 +5,7 @@ globals.forEach(function(g) {
   if (g in global) globalValues[g] = global[g];
 });
 
-require(process.env['PSEUDOLOC_COV'] ? "./pseudoloc-cov" : "./pseudoloc");
+require("./pseudoloc");
 
 module.exports = pseudoloc;
 


### PR DESCRIPTION
I missed this before when I was doing cleanup on the old build system (#3).