### PR TITLE
Fixes to padding algorithm and tests

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -25,7 +25,7 @@ _Pseudoloc_ includes a commandline interface to make it easy to incorporate it i
 
 Note: Nodejs must be installed to use the commandline interface.
 
-    node ./bin/pseudoloc -string 'A test string with a %token%.'
+    node ./bin/pseudoloc --string 'A test string with a %token%.'
     // [!!Á ţȇšŧ śťřīņğ ŵıţħ ą %token%.!!]
 
 

--- a/pseudoloc.js
+++ b/pseudoloc.js
@@ -66,7 +66,7 @@ pseudoloc = function() {
   pseudoloc.pad = function(str, percent) {
     var len = Math.floor(str.length * percent), pStr = str;
     while (len--) {
-      var array = [ "ö", "🐔", "ఛ", "ฒ", " ", "そ", "開", "अ", "㤌", "కె" ];
+      var array = [ "🐔", "𠜎", "𠜱", "𠲖", "𠴕", "𢺳", "🏆", "🤙", "𠸏", "𠸏" ];
       var tot = Math.floor(Math.random() * 10);
       pStr += array[tot];
     }

--- a/src/core/pad.js
+++ b/src/core/pad.js
@@ -14,7 +14,7 @@ pseudoloc.pad = function(str, percent) {
       pStr = str;
 
   while(len--) {
-    var array = [ 'ö', '🐔', 'ఛ', 'ฒ', ' ', 'そ', '開', 'अ', '㤌', 'కె'];
+    var array = [ '🐔', '𠜎', '𠜱', '𠲖', '𠴕', '𢺳', '🏆', '🤙', '𠸏', '𠸏'];
     var tot = Math.floor(Math.random() * 10)
     pStr += array[tot];
   }

--- a/test/str-test.js
+++ b/test/str-test.js
@@ -117,7 +117,7 @@ describe('pseudoloc.str', function() {
         var sInput = 'this is a test string';
         var s1 = pseudoloc.str(sInput);
         var lenInput = sInput.length;
-        s1.length.should.eql(32); // lazy accounting for double-byte padding characters
+        s1.length.should.eql(35); // lazy accounting for double-byte padding characters
     });
 
     it('should support a custom start token', function() {


### PR DESCRIPTION
- Changed padding characters so that they are all supplementary characters (above U+FFFF).
  Previously only one of the padding characters was above U+FFFF.
  This change guarantees that all padding characters are supplementary.
- Changed the test case to reflect this.
  Previous test case actually failed on some runs - it was expecting a length of 32, which wasn't the case if the algorithm chose the single supplementary character.
  (JavaScript counts supplementary character as being of length 2.)
- Fixed typo in Readme