### PR TITLE
Add bin configuration to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,6 +19,9 @@
             "exports": "pseudoloc"
         }
     },
+    "bin": {
+        "pseudoloc": "./bin/pseudoloc"
+    },
     "dependencies": {
         "commander": "*"
     },


### PR DESCRIPTION
so that `pseudoloc` is available on the command-line after a npm install.

re: https://github.com/bunkat/pseudoloc/issues/11